### PR TITLE
Use RMarkdown syntax

### DIFF
--- a/explicit-record-exercises/README.md
+++ b/explicit-record-exercises/README.md
@@ -1,7 +1,7 @@
 ## Instructions
 
 1. Open the R project i.e. the `.Rproj` file.
-2. Initiate {renv}} by running `renv::init()`.
+2. Initiate {renv} by running `renv::init()`.
 3. Check the identified dependencies by running `renv::dependencies()`.
     - What packages are required and why?
 4. Check the status of the dependencies by running `renv::status()`.

--- a/explicit-record-exercises/analysis_doc.qmd
+++ b/explicit-record-exercises/analysis_doc.qmd
@@ -4,7 +4,7 @@ format: html
 editor: visual
 ---
 
-## Example of Needing {sf} Package from Suggests of {ggplot2}
+## Example of Needing {maps} Package from Suggests of {ggplot2}
 
 Call in the ggplot2 package 
 

--- a/explicit-record-exercises/analysis_doc.qmd
+++ b/explicit-record-exercises/analysis_doc.qmd
@@ -22,7 +22,7 @@ Call map data using the map_data() function
 This will result in an error because the data for these maps is in the {maps} package, which is in the suggests of ggplot2. To fix this, you will need to record the {maps} in your `renv.lock` file.
 
 ```{r}
-ggplot(world, aes(x=long, y = lat, group = group)) +
+ggplot(world_map, aes(x=long, y = lat, group = group)) +
   geom_polygon() 
 ```
 

--- a/explicit-record-exercises/analysis_doc.qmd
+++ b/explicit-record-exercises/analysis_doc.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Example of Undeclared Dependency"
+lang: en
 format: html
 editor: visual
 ---

--- a/restore-exercises/presentation.rmd
+++ b/restore-exercises/presentation.rmd
@@ -1,7 +1,9 @@
 ---
 title: "Billboard 100 Presentation"
-format: html
-editor: visual
+output:
+  html_document:
+    theme:
+      version: 5
 ---
 
 

--- a/restore-exercises/presentation.rmd
+++ b/restore-exercises/presentation.rmd
@@ -1,5 +1,6 @@
 ---
 title: "Billboard 100 Presentation"
+lang: en
 output:
   html_document:
     theme:


### PR DESCRIPTION
The file `presentation.rmd` has the extension `.rmd` but uses the Quarto YAML fields `editor` and `format`. Rather remove them and set the output format as follows:

```yml
output:
  html_document:
    theme:
      version: 5
```